### PR TITLE
Show word score in result

### DIFF
--- a/skraflpermuter.py
+++ b/skraflpermuter.py
@@ -254,7 +254,7 @@ class Tabulator:
     def _add_permutation(self, word, score):
         """ Add a valid permulation to the tabulation result """
         self._counter += 1
-        self._allwords.append(word)
+        self._allwords.append(word + " (" + str(score) + ")")
         if score > self._highscore:
             # New high scoring word: note it and start a new list
             self._highscore = score

--- a/templates/result.html
+++ b/templates/result.html
@@ -19,10 +19,10 @@
          <div class="panel-body">
             <h3>
 {% for w in result.allwords() %}
-               <a href="/?rack={{ w|urlencode }}">
-{%- if (w|length) >= 7 -%}
+               <a href="/?rack={{ w.split()[0]|urlencode }}">
+{%- if (w.split()[0]|length) >= 7 -%}
                <span class="label label-danger resultword">
-{%- elif (w|length == result.rack()|length) -%}
+{%- elif (w.split()[0]|length == result.rack()|length) -%}
                <span class="label label-warning resultword">
 {%- else -%}
                <span class="label label-success resultword">
@@ -47,11 +47,10 @@
 {% for ch, l in result.combinations() %}
                <span class="label label-primary resultword">{{ ch }}</span>
 {%- for w in l -%}
-               
 {%- if loop.index == 1 -%}
 &nbsp;
 {%- endif -%}
-               <a href="/?rack={{ w|urlencode }}"><span class="label label-info resultword">{{ w }}</span></a>
+               <a href="/?rack={{ w.split()[0]|urlencode }}"><span class="label label-info resultword">{{ w }}</span></a>
 {% endfor %}
 {% endfor %}
             </h3>


### PR DESCRIPTION
Shows the word score for each word in paranthesis on result page.  It's a quick hack, but gets the job done. Does not show score for combinations, but that can quickly be added. 
![screenshot 2015-03-13 10 54 28](https://cloud.githubusercontent.com/assets/501816/6637204/79196f48-c96f-11e4-9489-912c43607b7b.png)
